### PR TITLE
Generate LuaLS docs and namespace class

### DIFF
--- a/lyte_api/defs/defs_lyte.lua
+++ b/lyte_api/defs/defs_lyte.lua
@@ -49,7 +49,7 @@ local lyte_namespace = Namespace("lyte", {
         Arg("window_width", Integer(), {optional=true, default=0.0}),
         Arg("window_height", Integer(), {optional=true, default=0.0}),
         Arg("window_resized", Boolean(), {optional=true, default=false}),
-    }, nil, {d="Tick function. Should be created by the user.", c_api_skip=true}),
+    }, nil, {d="Tick function. Should be created by the user.", c_api_skip=true, callback=true}),
 
     Function("quit", nil, nil, {d="Quit the application by closing the window."}),
 


### PR DESCRIPTION
This changes how `defs_to_docstrings` generates the lyte namespace and lyte.tick function. In my testing autocomplete didn't work without these changes (or it gave inaccurate diagnostics). I also made the generator comment each function/record/etc with the documentation provided in `defs_lyte`, and these comments show up as documentation in autocomplete popups.

So far it seems like this is all that's needed to get a nice autocomplete experience. I'm not sure how the definitions should be distributed, maybe `lyte.lua` could be included with releases and then the user could change their `Lua.workspace.library` variable in `.vscode/settings.json` to point to it manually. I checked what Love2D does and it looks like Love2D is so popular that LuaLS just includes it by default.