### PR TITLE
Use numbers instead of integers for drawing

### DIFF
--- a/lyte/api/defs/defs_lyte.lua
+++ b/lyte/api/defs/defs_lyte.lua
@@ -70,59 +70,59 @@ local lyte_namespace = Namespace("lyte", {
     Function("reset_color", nil, nil, {d="Reset the foreground color to its default value."}),
 
     Function("draw_point", {
-        Arg("x", Integer()),
-        Arg("y", Integer()),
+        Arg("x", Number()),
+        Arg("y", Number()),
     }, nil, {d="Draw a point."}),
 
     Function("draw_line", {
-        Arg("x1", Integer()),
-        Arg("y1", Integer()),
-        Arg("x2", Integer()),
-        Arg("y2", Integer()),
+        Arg("x1", Number()),
+        Arg("y1", Number()),
+        Arg("x2", Number()),
+        Arg("y2", Number()),
     }, nil, {d="Draw a line"}),
 
     Function("draw_triangle", {
-        Arg("ax", Integer()),
-        Arg("ay", Integer()),
-        Arg("bx", Integer()),
-        Arg("by", Integer()),
-        Arg("cx", Integer()),
-        Arg("cy", Integer()),
+        Arg("ax", Number()),
+        Arg("ay", Number()),
+        Arg("bx", Number()),
+        Arg("by", Number()),
+        Arg("cx", Number()),
+        Arg("cy", Number()),
     }, nil, {d="Draw a filled triangle"}),
 
     Function("draw_triangle_line", {
-        Arg("ax", Integer()),
-        Arg("ay", Integer()),
-        Arg("bx", Integer()),
-        Arg("by", Integer()),
-        Arg("cx", Integer()),
-        Arg("cy", Integer()),
+        Arg("ax", Number()),
+        Arg("ay", Number()),
+        Arg("bx", Number()),
+        Arg("by", Number()),
+        Arg("cx", Number()),
+        Arg("cy", Number()),
     }, nil, {d="Draw a triangle border"}),
 
     Function("draw_rect", {
-        Arg("dest_x", Integer()),
-        Arg("dest_y", Integer()),
-        Arg("rect_width", Integer()),
-        Arg("rect_height", Integer()),
+        Arg("dest_x", Number()),
+        Arg("dest_y", Number()),
+        Arg("rect_width", Number()),
+        Arg("rect_height", Number()),
     }, nil, {d="Draw a filled rectangle."}),
 
     Function("draw_rect_line", {
-        Arg("dest_x", Integer()),
-        Arg("dest_y", Integer()),
-        Arg("rect_width", Integer()),
-        Arg("rect_height", Integer()),
+        Arg("dest_x", Number()),
+        Arg("dest_y", Number()),
+        Arg("rect_width", Number()),
+        Arg("rect_height", Number()),
     }, nil, {d="Draw a rectangle border."}),
 
     Function("draw_circle", {
-        Arg("dest_x", Integer()),
-        Arg("dest_y", Integer()),
-        Arg("radius", Integer()),
+        Arg("dest_x", Number()),
+        Arg("dest_y", Number()),
+        Arg("radius", Number()),
     }, nil, {d="Draw a filled circle."}),
 
     Function("draw_circle_line", {
-        Arg("dest_x", Integer()),
-        Arg("dest_y", Integer()),
-        Arg("radius", Integer()),
+        Arg("dest_x", Number()),
+        Arg("dest_y", Number()),
+        Arg("radius", Number()),
     }, nil, {d="Draw a circle border."}),
 
     Function("load_image", {
@@ -133,18 +133,18 @@ local lyte_namespace = Namespace("lyte", {
 
     Function("draw_image", {
         Arg("image", Defined("Image")),
-        Arg("dest_x", Integer()),
-        Arg("dest_y", Integer()),
+        Arg("dest_x", Number()),
+        Arg("dest_y", Number()),
     }, nil, {d="Draw an image."}),
 
     Function("draw_image_rect", {
         Arg("image", Defined("Image")),
-        Arg("dest_x", Integer()),
-        Arg("dest_y", Integer()),
-        Arg("src_x", Integer()),
-        Arg("src_y", Integer()),
-        Arg("rect_width", Integer()),
-        Arg("rect_height", Integer()),
+        Arg("dest_x", Number()),
+        Arg("dest_y", Number()),
+        Arg("src_x", Number()),
+        Arg("src_y", Number()),
+        Arg("rect_width", Number()),
+        Arg("rect_height", Number()),
     }, nil, {d="Draw a rectangular area from the image."}),
 
     Function("get_image_width", {
@@ -190,14 +190,14 @@ local lyte_namespace = Namespace("lyte", {
 
     Function("add_imagebatch_rect", {
         Arg("imagebatch", Defined("ImageBatch")),
-        Arg("dest_x", Integer()),
-        Arg("dest_y", Integer()),
-        Arg("dest_width", Integer()),
-        Arg("dest_height", Integer()),
-        Arg("src_x", Integer()),
-        Arg("src_y", Integer()),
-        Arg("src_width", Integer()),
-        Arg("src_height", Integer()),
+        Arg("dest_x", Number()),
+        Arg("dest_y", Number()),
+        Arg("dest_width", Number()),
+        Arg("dest_height", Number()),
+        Arg("src_x", Number()),
+        Arg("src_y", Number()),
+        Arg("src_width", Number()),
+        Arg("src_height", Number()),
     }, nil, {d="Add a recta to the image batch (from it's initial image)."}),
 
     Function("get_imagebatch_rect_count", {
@@ -225,8 +225,8 @@ local lyte_namespace = Namespace("lyte", {
 
     Function("draw_text", {
         Arg("text", String()),
-        Arg("dest_x", Integer()),
-        Arg("dest_y", Integer()),
+        Arg("dest_x", Number()),
+        Arg("dest_y", Number()),
     }, nil, {d="Draw a text line."}),
 
     Function("get_text_width", {
@@ -598,8 +598,8 @@ local lyte_namespace = Namespace("lyte", {
     Function("reset_matrix", nil, nil, {d="Reset the transformation matrix (load identity matrix.)"}),
 
     Function("translate", {
-        Arg("delta_x", Integer()),
-        Arg("delta_y", Integer()),
+        Arg("delta_x", Number()),
+        Arg("delta_y", Number()),
     }, nil, {d="Apply translation (changes transform matrix.)"}),
 
     Function("rotate", {
@@ -608,8 +608,8 @@ local lyte_namespace = Namespace("lyte", {
 
     Function("rotate_at", {
         Arg("angle", Number()),
-        Arg("x", Integer()),
-        Arg("y", Integer()),
+        Arg("x", Number()),
+        Arg("y", Number()),
     }, nil, {d="Apply rotation at the given location (changes transform matrix.)"}),
 
     Function("scale", {
@@ -618,8 +618,8 @@ local lyte_namespace = Namespace("lyte", {
     }, nil, {d="Apply scaling (changes transform matrix.)"}),
 
     Function("scale_at", {
-        Arg("scale_x", Integer()),
-        Arg("scale_y", Integer()),
+        Arg("scale_x", Number()),
+        Arg("scale_y", Number()),
         Arg("x", Number()),
         Arg("y", Number()),
     }, nil, {d="Apply scaling at the given location (changes transform matrix.)"}),

--- a/lyte/api/defs/output/api.impl.c
+++ b/lyte/api/defs/output/api.impl.c
@@ -44,49 +44,49 @@ static inline int _reset_color(void) {
     _err = lyte_reset_color();
     return _err;
 }
-static inline int _draw_point(int x, int y) {
+static inline int _draw_point(double x, double y) {
     (void)x;(void)y;
     int _err = 0;
     _err = lyte_draw_point(x, y);
     return _err;
 }
-static inline int _draw_line(int x1, int y1, int x2, int y2) {
+static inline int _draw_line(double x1, double y1, double x2, double y2) {
     (void)x1;(void)y1;(void)x2;(void)y2;
     int _err = 0;
     _err = lyte_draw_line(x1, y1, x2, y2);
     return _err;
 }
-static inline int _draw_triangle(int ax, int ay, int bx, int by, int cx, int cy) {
+static inline int _draw_triangle(double ax, double ay, double bx, double by, double cx, double cy) {
     (void)ax;(void)ay;(void)bx;(void)by;(void)cx;(void)cy;
     int _err = 0;
     _err = lyte_draw_triangle(ax, ay, bx, by, cx, cy);
     return _err;
 }
-static inline int _draw_triangle_line(int ax, int ay, int bx, int by, int cx, int cy) {
+static inline int _draw_triangle_line(double ax, double ay, double bx, double by, double cx, double cy) {
     (void)ax;(void)ay;(void)bx;(void)by;(void)cx;(void)cy;
     int _err = 0;
     _err = lyte_draw_triangle_line(ax, ay, bx, by, cx, cy);
     return _err;
 }
-static inline int _draw_rect(int dest_x, int dest_y, int rect_width, int rect_height) {
+static inline int _draw_rect(double dest_x, double dest_y, double rect_width, double rect_height) {
     (void)dest_x;(void)dest_y;(void)rect_width;(void)rect_height;
     int _err = 0;
     _err = lyte_draw_rect(dest_x, dest_y, rect_width, rect_height);
     return _err;
 }
-static inline int _draw_rect_line(int dest_x, int dest_y, int rect_width, int rect_height) {
+static inline int _draw_rect_line(double dest_x, double dest_y, double rect_width, double rect_height) {
     (void)dest_x;(void)dest_y;(void)rect_width;(void)rect_height;
     int _err = 0;
     _err = lyte_draw_rect_line(dest_x, dest_y, rect_width, rect_height);
     return _err;
 }
-static inline int _draw_circle(int dest_x, int dest_y, int radius) {
+static inline int _draw_circle(double dest_x, double dest_y, double radius) {
     (void)dest_x;(void)dest_y;(void)radius;
     int _err = 0;
     _err = lyte_draw_circle(dest_x, dest_y, radius);
     return _err;
 }
-static inline int _draw_circle_line(int dest_x, int dest_y, int radius) {
+static inline int _draw_circle_line(double dest_x, double dest_y, double radius) {
     (void)dest_x;(void)dest_y;(void)radius;
     int _err = 0;
     _err = lyte_draw_circle_line(dest_x, dest_y, radius);
@@ -98,13 +98,13 @@ static inline int _load_image(const char * image_path, lyte_Image *val) {
     _err = lyte_load_image(image_path, val);
     return _err;
 }
-static inline int _draw_image(lyte_Image image, int dest_x, int dest_y) {
+static inline int _draw_image(lyte_Image image, double dest_x, double dest_y) {
     (void)image;(void)dest_x;(void)dest_y;
     int _err = 0;
     _err = lyte_draw_image(image, dest_x, dest_y);
     return _err;
 }
-static inline int _draw_image_rect(lyte_Image image, int dest_x, int dest_y, int src_x, int src_y, int rect_width, int rect_height) {
+static inline int _draw_image_rect(lyte_Image image, double dest_x, double dest_y, double src_x, double src_y, double rect_width, double rect_height) {
     (void)image;(void)dest_x;(void)dest_y;(void)src_x;(void)src_y;(void)rect_width;(void)rect_height;
     int _err = 0;
     _err = lyte_draw_image_rect(image, dest_x, dest_y, src_x, src_y, rect_width, rect_height);
@@ -157,7 +157,7 @@ static inline int _reset_imagebatch(lyte_ImageBatch imagebatch) {
     _err = lyte_reset_imagebatch(imagebatch);
     return _err;
 }
-static inline int _add_imagebatch_rect(lyte_ImageBatch imagebatch, int dest_x, int dest_y, int dest_width, int dest_height, int src_x, int src_y, int src_width, int src_height) {
+static inline int _add_imagebatch_rect(lyte_ImageBatch imagebatch, double dest_x, double dest_y, double dest_width, double dest_height, double src_x, double src_y, double src_width, double src_height) {
     (void)imagebatch;(void)dest_x;(void)dest_y;(void)dest_width;(void)dest_height;(void)src_x;(void)src_y;(void)src_width;(void)src_height;
     int _err = 0;
     _err = lyte_add_imagebatch_rect(imagebatch, dest_x, dest_y, dest_width, dest_height, src_x, src_y, src_width, src_height);
@@ -187,7 +187,7 @@ static inline int _set_font(lyte_Font font) {
     _err = lyte_set_font(font);
     return _err;
 }
-static inline int _draw_text(const char * text, int dest_x, int dest_y) {
+static inline int _draw_text(const char * text, double dest_x, double dest_y) {
     (void)text;(void)dest_x;(void)dest_y;
     int _err = 0;
     _err = lyte_draw_text(text, dest_x, dest_y);
@@ -622,7 +622,7 @@ static inline int _reset_matrix(void) {
     _err = lyte_reset_matrix();
     return _err;
 }
-static inline int _translate(int delta_x, int delta_y) {
+static inline int _translate(double delta_x, double delta_y) {
     (void)delta_x;(void)delta_y;
     int _err = 0;
     _err = lyte_translate(delta_x, delta_y);
@@ -634,7 +634,7 @@ static inline int _rotate(double angle) {
     _err = lyte_rotate(angle);
     return _err;
 }
-static inline int _rotate_at(double angle, int x, int y) {
+static inline int _rotate_at(double angle, double x, double y) {
     (void)angle;(void)x;(void)y;
     int _err = 0;
     _err = lyte_rotate_at(angle, x, y);
@@ -646,7 +646,7 @@ static inline int _scale(double scale_x, double scale_y) {
     _err = lyte_scale(scale_x, scale_y);
     return _err;
 }
-static inline int _scale_at(int scale_x, int scale_y, double x, double y) {
+static inline int _scale_at(double scale_x, double scale_y, double x, double y) {
     (void)scale_x;(void)scale_y;(void)x;(void)y;
     int _err = 0;
     _err = lyte_scale_at(scale_x, scale_y, x, y);

--- a/lyte/api/defs/output/api_generated.c
+++ b/lyte/api/defs/output/api_generated.c
@@ -255,8 +255,8 @@ static int api_reset_color(lua_State *L) {
 // draw_point: [ number  number -- ]
 static int api_draw_point(lua_State *L) {
     (void)L;
-    int x = luaL_checkinteger(L, 1);
-    int y = luaL_checkinteger(L, 2);
+    double x = luaL_checknumber(L, 1);
+    double y = luaL_checknumber(L, 2);
     int _err = _draw_point(x, y);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -264,10 +264,10 @@ static int api_draw_point(lua_State *L) {
 // draw_line: [ number  number  number  number -- ]
 static int api_draw_line(lua_State *L) {
     (void)L;
-    int x1 = luaL_checkinteger(L, 1);
-    int y1 = luaL_checkinteger(L, 2);
-    int x2 = luaL_checkinteger(L, 3);
-    int y2 = luaL_checkinteger(L, 4);
+    double x1 = luaL_checknumber(L, 1);
+    double y1 = luaL_checknumber(L, 2);
+    double x2 = luaL_checknumber(L, 3);
+    double y2 = luaL_checknumber(L, 4);
     int _err = _draw_line(x1, y1, x2, y2);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -275,12 +275,12 @@ static int api_draw_line(lua_State *L) {
 // draw_triangle: [ number  number  number  number  number  number -- ]
 static int api_draw_triangle(lua_State *L) {
     (void)L;
-    int ax = luaL_checkinteger(L, 1);
-    int ay = luaL_checkinteger(L, 2);
-    int bx = luaL_checkinteger(L, 3);
-    int by = luaL_checkinteger(L, 4);
-    int cx = luaL_checkinteger(L, 5);
-    int cy = luaL_checkinteger(L, 6);
+    double ax = luaL_checknumber(L, 1);
+    double ay = luaL_checknumber(L, 2);
+    double bx = luaL_checknumber(L, 3);
+    double by = luaL_checknumber(L, 4);
+    double cx = luaL_checknumber(L, 5);
+    double cy = luaL_checknumber(L, 6);
     int _err = _draw_triangle(ax, ay, bx, by, cx, cy);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -288,12 +288,12 @@ static int api_draw_triangle(lua_State *L) {
 // draw_triangle_line: [ number  number  number  number  number  number -- ]
 static int api_draw_triangle_line(lua_State *L) {
     (void)L;
-    int ax = luaL_checkinteger(L, 1);
-    int ay = luaL_checkinteger(L, 2);
-    int bx = luaL_checkinteger(L, 3);
-    int by = luaL_checkinteger(L, 4);
-    int cx = luaL_checkinteger(L, 5);
-    int cy = luaL_checkinteger(L, 6);
+    double ax = luaL_checknumber(L, 1);
+    double ay = luaL_checknumber(L, 2);
+    double bx = luaL_checknumber(L, 3);
+    double by = luaL_checknumber(L, 4);
+    double cx = luaL_checknumber(L, 5);
+    double cy = luaL_checknumber(L, 6);
     int _err = _draw_triangle_line(ax, ay, bx, by, cx, cy);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -301,10 +301,10 @@ static int api_draw_triangle_line(lua_State *L) {
 // draw_rect: [ number  number  number  number -- ]
 static int api_draw_rect(lua_State *L) {
     (void)L;
-    int dest_x = luaL_checkinteger(L, 1);
-    int dest_y = luaL_checkinteger(L, 2);
-    int rect_width = luaL_checkinteger(L, 3);
-    int rect_height = luaL_checkinteger(L, 4);
+    double dest_x = luaL_checknumber(L, 1);
+    double dest_y = luaL_checknumber(L, 2);
+    double rect_width = luaL_checknumber(L, 3);
+    double rect_height = luaL_checknumber(L, 4);
     int _err = _draw_rect(dest_x, dest_y, rect_width, rect_height);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -312,10 +312,10 @@ static int api_draw_rect(lua_State *L) {
 // draw_rect_line: [ number  number  number  number -- ]
 static int api_draw_rect_line(lua_State *L) {
     (void)L;
-    int dest_x = luaL_checkinteger(L, 1);
-    int dest_y = luaL_checkinteger(L, 2);
-    int rect_width = luaL_checkinteger(L, 3);
-    int rect_height = luaL_checkinteger(L, 4);
+    double dest_x = luaL_checknumber(L, 1);
+    double dest_y = luaL_checknumber(L, 2);
+    double rect_width = luaL_checknumber(L, 3);
+    double rect_height = luaL_checknumber(L, 4);
     int _err = _draw_rect_line(dest_x, dest_y, rect_width, rect_height);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -323,9 +323,9 @@ static int api_draw_rect_line(lua_State *L) {
 // draw_circle: [ number  number  number -- ]
 static int api_draw_circle(lua_State *L) {
     (void)L;
-    int dest_x = luaL_checkinteger(L, 1);
-    int dest_y = luaL_checkinteger(L, 2);
-    int radius = luaL_checkinteger(L, 3);
+    double dest_x = luaL_checknumber(L, 1);
+    double dest_y = luaL_checknumber(L, 2);
+    double radius = luaL_checknumber(L, 3);
     int _err = _draw_circle(dest_x, dest_y, radius);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -333,9 +333,9 @@ static int api_draw_circle(lua_State *L) {
 // draw_circle_line: [ number  number  number -- ]
 static int api_draw_circle_line(lua_State *L) {
     (void)L;
-    int dest_x = luaL_checkinteger(L, 1);
-    int dest_y = luaL_checkinteger(L, 2);
-    int radius = luaL_checkinteger(L, 3);
+    double dest_x = luaL_checknumber(L, 1);
+    double dest_y = luaL_checknumber(L, 2);
+    double radius = luaL_checknumber(L, 3);
     int _err = _draw_circle_line(dest_x, dest_y, radius);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -356,8 +356,8 @@ static int api_load_image(lua_State *L) {
 static int api_draw_image(lua_State *L) {
     (void)L;
     lyte_Image *image = luaL_checkudata(L, 1, "lyte.Image");
-    int dest_x = luaL_checkinteger(L, 2);
-    int dest_y = luaL_checkinteger(L, 3);
+    double dest_x = luaL_checknumber(L, 2);
+    double dest_y = luaL_checknumber(L, 3);
     int _err = _draw_image(*image, dest_x, dest_y);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -366,12 +366,12 @@ static int api_draw_image(lua_State *L) {
 static int api_draw_image_rect(lua_State *L) {
     (void)L;
     lyte_Image *image = luaL_checkudata(L, 1, "lyte.Image");
-    int dest_x = luaL_checkinteger(L, 2);
-    int dest_y = luaL_checkinteger(L, 3);
-    int src_x = luaL_checkinteger(L, 4);
-    int src_y = luaL_checkinteger(L, 5);
-    int rect_width = luaL_checkinteger(L, 6);
-    int rect_height = luaL_checkinteger(L, 7);
+    double dest_x = luaL_checknumber(L, 2);
+    double dest_y = luaL_checknumber(L, 3);
+    double src_x = luaL_checknumber(L, 4);
+    double src_y = luaL_checknumber(L, 5);
+    double rect_width = luaL_checknumber(L, 6);
+    double rect_height = luaL_checknumber(L, 7);
     int _err = _draw_image_rect(*image, dest_x, dest_y, src_x, src_y, rect_width, rect_height);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -461,14 +461,14 @@ static int api_reset_imagebatch(lua_State *L) {
 static int api_add_imagebatch_rect(lua_State *L) {
     (void)L;
     lyte_ImageBatch *imagebatch = luaL_checkudata(L, 1, "lyte.ImageBatch");
-    int dest_x = luaL_checkinteger(L, 2);
-    int dest_y = luaL_checkinteger(L, 3);
-    int dest_width = luaL_checkinteger(L, 4);
-    int dest_height = luaL_checkinteger(L, 5);
-    int src_x = luaL_checkinteger(L, 6);
-    int src_y = luaL_checkinteger(L, 7);
-    int src_width = luaL_checkinteger(L, 8);
-    int src_height = luaL_checkinteger(L, 9);
+    double dest_x = luaL_checknumber(L, 2);
+    double dest_y = luaL_checknumber(L, 3);
+    double dest_width = luaL_checknumber(L, 4);
+    double dest_height = luaL_checknumber(L, 5);
+    double src_x = luaL_checknumber(L, 6);
+    double src_y = luaL_checknumber(L, 7);
+    double src_width = luaL_checknumber(L, 8);
+    double src_height = luaL_checknumber(L, 9);
     int _err = _add_imagebatch_rect(*imagebatch, dest_x, dest_y, dest_width, dest_height, src_x, src_y, src_width, src_height);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -519,8 +519,8 @@ static int api_set_font(lua_State *L) {
 static int api_draw_text(lua_State *L) {
     (void)L;
     const char * text = luaL_checkstring(L, 1);
-    int dest_x = luaL_checkinteger(L, 2);
-    int dest_y = luaL_checkinteger(L, 3);
+    double dest_x = luaL_checknumber(L, 2);
+    double dest_y = luaL_checknumber(L, 3);
     int _err = _draw_text(text, dest_x, dest_y);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -1214,8 +1214,8 @@ static int api_reset_matrix(lua_State *L) {
 // translate: [ number  number -- ]
 static int api_translate(lua_State *L) {
     (void)L;
-    int delta_x = luaL_checkinteger(L, 1);
-    int delta_y = luaL_checkinteger(L, 2);
+    double delta_x = luaL_checknumber(L, 1);
+    double delta_y = luaL_checknumber(L, 2);
     int _err = _translate(delta_x, delta_y);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -1232,8 +1232,8 @@ static int api_rotate(lua_State *L) {
 static int api_rotate_at(lua_State *L) {
     (void)L;
     double angle = luaL_checknumber(L, 1);
-    int x = luaL_checkinteger(L, 2);
-    int y = luaL_checkinteger(L, 3);
+    double x = luaL_checknumber(L, 2);
+    double y = luaL_checknumber(L, 3);
     int _err = _rotate_at(angle, x, y);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -1250,8 +1250,8 @@ static int api_scale(lua_State *L) {
 // scale_at: [ number  number  number  number -- ]
 static int api_scale_at(lua_State *L) {
     (void)L;
-    int scale_x = luaL_checkinteger(L, 1);
-    int scale_y = luaL_checkinteger(L, 2);
+    double scale_x = luaL_checknumber(L, 1);
+    double scale_y = luaL_checknumber(L, 2);
     double x = luaL_checknumber(L, 3);
     double y = luaL_checknumber(L, 4);
     int _err = _scale_at(scale_x, scale_y, x, y);

--- a/lyte/api/src/api.impl.c
+++ b/lyte/api/src/api.impl.c
@@ -46,49 +46,49 @@ static inline int _reset_color(void) {
     _err = lyte_reset_color();
     return _err;
 }
-static inline int _draw_point(int x, int y) {
+static inline int _draw_point(double x, double y) {
     (void)x;(void)y;
     int _err = 0;
     _err = lyte_draw_point(x, y);
     return _err;
 }
-static inline int _draw_line(int x1, int y1, int x2, int y2) {
+static inline int _draw_line(double x1, double y1, double x2, double y2) {
     (void)x1;(void)y1;(void)x2;(void)y2;
     int _err = 0;
     _err = lyte_draw_line(x1, y1, x2, y2);
     return _err;
 }
-static inline int _draw_triangle(int ax, int ay, int bx, int by, int cx, int cy) {
+static inline int _draw_triangle(double ax, double ay, double bx, double by, double cx, double cy) {
     (void)ax;(void)ay;(void)bx;(void)by;(void)cx;(void)cy;
     int _err = 0;
     _err = lyte_draw_triangle(ax, ay, bx, by, cx, cy);
     return _err;
 }
-static inline int _draw_triangle_line(int ax, int ay, int bx, int by, int cx, int cy) {
+static inline int _draw_triangle_line(double ax, double ay, double bx, double by, double cx, double cy) {
     (void)ax;(void)ay;(void)bx;(void)by;(void)cx;(void)cy;
     int _err = 0;
     _err = lyte_draw_triangle_line(ax, ay, bx, by, cx, cy);
     return _err;
 }
-static inline int _draw_rect(int dest_x, int dest_y, int rect_width, int rect_height) {
+static inline int _draw_rect(double dest_x, double dest_y, double rect_width, double rect_height) {
     (void)dest_x;(void)dest_y;(void)rect_width;(void)rect_height;
     int _err = 0;
     _err = lyte_draw_rect(dest_x, dest_y, rect_width, rect_height);
     return _err;
 }
-static inline int _draw_rect_line(int dest_x, int dest_y, int rect_width, int rect_height) {
+static inline int _draw_rect_line(double dest_x, double dest_y, double rect_width, double rect_height) {
     (void)dest_x;(void)dest_y;(void)rect_width;(void)rect_height;
     int _err = 0;
     _err = lyte_draw_rect_line(dest_x, dest_y, rect_width, rect_height);
     return _err;
 }
-static inline int _draw_circle(int dest_x, int dest_y, int radius) {
+static inline int _draw_circle(double dest_x, double dest_y, double radius) {
     (void)dest_x;(void)dest_y;(void)radius;
     int _err = 0;
     _err = lyte_draw_circle(dest_x, dest_y, radius);
     return _err;
 }
-static inline int _draw_circle_line(int dest_x, int dest_y, int radius) {
+static inline int _draw_circle_line(double dest_x, double dest_y, double radius) {
     (void)dest_x;(void)dest_y;(void)radius;
     int _err = 0;
     _err = lyte_draw_circle_line(dest_x, dest_y, radius);
@@ -100,13 +100,13 @@ static inline int _load_image(const char * image_path, lyte_Image *val) {
     _err = lyte_load_image(image_path, val);
     return _err;
 }
-static inline int _draw_image(lyte_Image image, int dest_x, int dest_y) {
+static inline int _draw_image(lyte_Image image, double dest_x, double dest_y) {
     (void)image;(void)dest_x;(void)dest_y;
     int _err = 0;
     _err = lyte_draw_image(image, dest_x, dest_y);
     return _err;
 }
-static inline int _draw_image_rect(lyte_Image image, int dest_x, int dest_y, int src_x, int src_y, int rect_width, int rect_height) {
+static inline int _draw_image_rect(lyte_Image image, double dest_x, double dest_y, double src_x, double src_y, double rect_width, double rect_height) {
     (void)image;(void)dest_x;(void)dest_y;(void)src_x;(void)src_y;(void)rect_width;(void)rect_height;
     int _err = 0;
     _err = lyte_draw_image_rect(image, dest_x, dest_y, src_x, src_y, rect_width, rect_height);
@@ -159,7 +159,7 @@ static inline int _reset_imagebatch(lyte_ImageBatch imagebatch) {
     _err = lyte_reset_imagebatch(imagebatch);
     return _err;
 }
-static inline int _add_imagebatch_rect(lyte_ImageBatch imagebatch, int dest_x, int dest_y, int dest_width, int dest_height, int src_x, int src_y, int src_width, int src_height) {
+static inline int _add_imagebatch_rect(lyte_ImageBatch imagebatch, double dest_x, double dest_y, double dest_width, double dest_height, double src_x, double src_y, double src_width, double src_height) {
     (void)imagebatch;(void)dest_x;(void)dest_y;(void)dest_width;(void)dest_height;(void)src_x;(void)src_y;(void)src_width;(void)src_height;
     int _err = 0;
     _err = lyte_add_imagebatch_rect(imagebatch, dest_x, dest_y, dest_width, dest_height, src_x, src_y, src_width, src_height);
@@ -189,7 +189,7 @@ static inline int _set_font(lyte_Font font) {
     _err = lyte_set_font(font);
     return _err;
 }
-static inline int _draw_text(const char * text, int dest_x, int dest_y) {
+static inline int _draw_text(const char * text, double dest_x, double dest_y) {
     (void)text;(void)dest_x;(void)dest_y;
     int _err = 0;
     _err = lyte_draw_text(text, dest_x, dest_y);
@@ -624,7 +624,7 @@ static inline int _reset_matrix(void) {
     _err = lyte_reset_matrix();
     return _err;
 }
-static inline int _translate(int delta_x, int delta_y) {
+static inline int _translate(double delta_x, double delta_y) {
     (void)delta_x;(void)delta_y;
     int _err = 0;
     _err = lyte_translate(delta_x, delta_y);
@@ -636,7 +636,7 @@ static inline int _rotate(double angle) {
     _err = lyte_rotate(angle);
     return _err;
 }
-static inline int _rotate_at(double angle, int x, int y) {
+static inline int _rotate_at(double angle, double x, double y) {
     (void)angle;(void)x;(void)y;
     int _err = 0;
     _err = lyte_rotate_at(angle, x, y);
@@ -648,7 +648,7 @@ static inline int _scale(double scale_x, double scale_y) {
     _err = lyte_scale(scale_x, scale_y);
     return _err;
 }
-static inline int _scale_at(int scale_x, int scale_y, double x, double y) {
+static inline int _scale_at(double scale_x, double scale_y, double x, double y) {
     (void)scale_x;(void)scale_y;(void)x;(void)y;
     int _err = 0;
     _err = lyte_scale_at(scale_x, scale_y, x, y);

--- a/lyte/api/src/api_generated.c
+++ b/lyte/api/src/api_generated.c
@@ -255,8 +255,8 @@ static int api_reset_color(lua_State *L) {
 // draw_point: [ number  number -- ]
 static int api_draw_point(lua_State *L) {
     (void)L;
-    int x = luaL_checkinteger(L, 1);
-    int y = luaL_checkinteger(L, 2);
+    double x = luaL_checknumber(L, 1);
+    double y = luaL_checknumber(L, 2);
     int _err = _draw_point(x, y);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -264,10 +264,10 @@ static int api_draw_point(lua_State *L) {
 // draw_line: [ number  number  number  number -- ]
 static int api_draw_line(lua_State *L) {
     (void)L;
-    int x1 = luaL_checkinteger(L, 1);
-    int y1 = luaL_checkinteger(L, 2);
-    int x2 = luaL_checkinteger(L, 3);
-    int y2 = luaL_checkinteger(L, 4);
+    double x1 = luaL_checknumber(L, 1);
+    double y1 = luaL_checknumber(L, 2);
+    double x2 = luaL_checknumber(L, 3);
+    double y2 = luaL_checknumber(L, 4);
     int _err = _draw_line(x1, y1, x2, y2);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -275,12 +275,12 @@ static int api_draw_line(lua_State *L) {
 // draw_triangle: [ number  number  number  number  number  number -- ]
 static int api_draw_triangle(lua_State *L) {
     (void)L;
-    int ax = luaL_checkinteger(L, 1);
-    int ay = luaL_checkinteger(L, 2);
-    int bx = luaL_checkinteger(L, 3);
-    int by = luaL_checkinteger(L, 4);
-    int cx = luaL_checkinteger(L, 5);
-    int cy = luaL_checkinteger(L, 6);
+    double ax = luaL_checknumber(L, 1);
+    double ay = luaL_checknumber(L, 2);
+    double bx = luaL_checknumber(L, 3);
+    double by = luaL_checknumber(L, 4);
+    double cx = luaL_checknumber(L, 5);
+    double cy = luaL_checknumber(L, 6);
     int _err = _draw_triangle(ax, ay, bx, by, cx, cy);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -288,12 +288,12 @@ static int api_draw_triangle(lua_State *L) {
 // draw_triangle_line: [ number  number  number  number  number  number -- ]
 static int api_draw_triangle_line(lua_State *L) {
     (void)L;
-    int ax = luaL_checkinteger(L, 1);
-    int ay = luaL_checkinteger(L, 2);
-    int bx = luaL_checkinteger(L, 3);
-    int by = luaL_checkinteger(L, 4);
-    int cx = luaL_checkinteger(L, 5);
-    int cy = luaL_checkinteger(L, 6);
+    double ax = luaL_checknumber(L, 1);
+    double ay = luaL_checknumber(L, 2);
+    double bx = luaL_checknumber(L, 3);
+    double by = luaL_checknumber(L, 4);
+    double cx = luaL_checknumber(L, 5);
+    double cy = luaL_checknumber(L, 6);
     int _err = _draw_triangle_line(ax, ay, bx, by, cx, cy);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -301,10 +301,10 @@ static int api_draw_triangle_line(lua_State *L) {
 // draw_rect: [ number  number  number  number -- ]
 static int api_draw_rect(lua_State *L) {
     (void)L;
-    int dest_x = luaL_checkinteger(L, 1);
-    int dest_y = luaL_checkinteger(L, 2);
-    int rect_width = luaL_checkinteger(L, 3);
-    int rect_height = luaL_checkinteger(L, 4);
+    double dest_x = luaL_checknumber(L, 1);
+    double dest_y = luaL_checknumber(L, 2);
+    double rect_width = luaL_checknumber(L, 3);
+    double rect_height = luaL_checknumber(L, 4);
     int _err = _draw_rect(dest_x, dest_y, rect_width, rect_height);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -312,10 +312,10 @@ static int api_draw_rect(lua_State *L) {
 // draw_rect_line: [ number  number  number  number -- ]
 static int api_draw_rect_line(lua_State *L) {
     (void)L;
-    int dest_x = luaL_checkinteger(L, 1);
-    int dest_y = luaL_checkinteger(L, 2);
-    int rect_width = luaL_checkinteger(L, 3);
-    int rect_height = luaL_checkinteger(L, 4);
+    double dest_x = luaL_checknumber(L, 1);
+    double dest_y = luaL_checknumber(L, 2);
+    double rect_width = luaL_checknumber(L, 3);
+    double rect_height = luaL_checknumber(L, 4);
     int _err = _draw_rect_line(dest_x, dest_y, rect_width, rect_height);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -323,9 +323,9 @@ static int api_draw_rect_line(lua_State *L) {
 // draw_circle: [ number  number  number -- ]
 static int api_draw_circle(lua_State *L) {
     (void)L;
-    int dest_x = luaL_checkinteger(L, 1);
-    int dest_y = luaL_checkinteger(L, 2);
-    int radius = luaL_checkinteger(L, 3);
+    double dest_x = luaL_checknumber(L, 1);
+    double dest_y = luaL_checknumber(L, 2);
+    double radius = luaL_checknumber(L, 3);
     int _err = _draw_circle(dest_x, dest_y, radius);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -333,9 +333,9 @@ static int api_draw_circle(lua_State *L) {
 // draw_circle_line: [ number  number  number -- ]
 static int api_draw_circle_line(lua_State *L) {
     (void)L;
-    int dest_x = luaL_checkinteger(L, 1);
-    int dest_y = luaL_checkinteger(L, 2);
-    int radius = luaL_checkinteger(L, 3);
+    double dest_x = luaL_checknumber(L, 1);
+    double dest_y = luaL_checknumber(L, 2);
+    double radius = luaL_checknumber(L, 3);
     int _err = _draw_circle_line(dest_x, dest_y, radius);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -356,8 +356,8 @@ static int api_load_image(lua_State *L) {
 static int api_draw_image(lua_State *L) {
     (void)L;
     lyte_Image *image = luaL_checkudata(L, 1, "lyte.Image");
-    int dest_x = luaL_checkinteger(L, 2);
-    int dest_y = luaL_checkinteger(L, 3);
+    double dest_x = luaL_checknumber(L, 2);
+    double dest_y = luaL_checknumber(L, 3);
     int _err = _draw_image(*image, dest_x, dest_y);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -366,12 +366,12 @@ static int api_draw_image(lua_State *L) {
 static int api_draw_image_rect(lua_State *L) {
     (void)L;
     lyte_Image *image = luaL_checkudata(L, 1, "lyte.Image");
-    int dest_x = luaL_checkinteger(L, 2);
-    int dest_y = luaL_checkinteger(L, 3);
-    int src_x = luaL_checkinteger(L, 4);
-    int src_y = luaL_checkinteger(L, 5);
-    int rect_width = luaL_checkinteger(L, 6);
-    int rect_height = luaL_checkinteger(L, 7);
+    double dest_x = luaL_checknumber(L, 2);
+    double dest_y = luaL_checknumber(L, 3);
+    double src_x = luaL_checknumber(L, 4);
+    double src_y = luaL_checknumber(L, 5);
+    double rect_width = luaL_checknumber(L, 6);
+    double rect_height = luaL_checknumber(L, 7);
     int _err = _draw_image_rect(*image, dest_x, dest_y, src_x, src_y, rect_width, rect_height);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -461,14 +461,14 @@ static int api_reset_imagebatch(lua_State *L) {
 static int api_add_imagebatch_rect(lua_State *L) {
     (void)L;
     lyte_ImageBatch *imagebatch = luaL_checkudata(L, 1, "lyte.ImageBatch");
-    int dest_x = luaL_checkinteger(L, 2);
-    int dest_y = luaL_checkinteger(L, 3);
-    int dest_width = luaL_checkinteger(L, 4);
-    int dest_height = luaL_checkinteger(L, 5);
-    int src_x = luaL_checkinteger(L, 6);
-    int src_y = luaL_checkinteger(L, 7);
-    int src_width = luaL_checkinteger(L, 8);
-    int src_height = luaL_checkinteger(L, 9);
+    double dest_x = luaL_checknumber(L, 2);
+    double dest_y = luaL_checknumber(L, 3);
+    double dest_width = luaL_checknumber(L, 4);
+    double dest_height = luaL_checknumber(L, 5);
+    double src_x = luaL_checknumber(L, 6);
+    double src_y = luaL_checknumber(L, 7);
+    double src_width = luaL_checknumber(L, 8);
+    double src_height = luaL_checknumber(L, 9);
     int _err = _add_imagebatch_rect(*imagebatch, dest_x, dest_y, dest_width, dest_height, src_x, src_y, src_width, src_height);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -519,8 +519,8 @@ static int api_set_font(lua_State *L) {
 static int api_draw_text(lua_State *L) {
     (void)L;
     const char * text = luaL_checkstring(L, 1);
-    int dest_x = luaL_checkinteger(L, 2);
-    int dest_y = luaL_checkinteger(L, 3);
+    double dest_x = luaL_checknumber(L, 2);
+    double dest_y = luaL_checknumber(L, 3);
     int _err = _draw_text(text, dest_x, dest_y);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -1214,8 +1214,8 @@ static int api_reset_matrix(lua_State *L) {
 // translate: [ number  number -- ]
 static int api_translate(lua_State *L) {
     (void)L;
-    int delta_x = luaL_checkinteger(L, 1);
-    int delta_y = luaL_checkinteger(L, 2);
+    double delta_x = luaL_checknumber(L, 1);
+    double delta_y = luaL_checknumber(L, 2);
     int _err = _translate(delta_x, delta_y);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -1232,8 +1232,8 @@ static int api_rotate(lua_State *L) {
 static int api_rotate_at(lua_State *L) {
     (void)L;
     double angle = luaL_checknumber(L, 1);
-    int x = luaL_checkinteger(L, 2);
-    int y = luaL_checkinteger(L, 3);
+    double x = luaL_checknumber(L, 2);
+    double y = luaL_checknumber(L, 3);
     int _err = _rotate_at(angle, x, y);
     (void)_err;  // TODO: handle '_err' in case it's not 0
     return 0; // number of return values
@@ -1250,8 +1250,8 @@ static int api_scale(lua_State *L) {
 // scale_at: [ number  number  number  number -- ]
 static int api_scale_at(lua_State *L) {
     (void)L;
-    int scale_x = luaL_checkinteger(L, 1);
-    int scale_y = luaL_checkinteger(L, 2);
+    double scale_x = luaL_checknumber(L, 1);
+    double scale_y = luaL_checknumber(L, 2);
     double x = luaL_checknumber(L, 3);
     double y = luaL_checknumber(L, 4);
     int _err = _scale_at(scale_x, scale_y, x, y);

--- a/lyte_core/include/lyte_core.h
+++ b/lyte_core/include/lyte_core.h
@@ -119,11 +119,11 @@ int lyte_cls(double r, double g, double b, double a);
 int lyte_push_matrix(void);
 int lyte_pop_matrix(void);
 int lyte_reset_matrix(void);
-int lyte_translate(int delta_x, int delta_y);
+int lyte_translate(double delta_x, double delta_y);
 int lyte_rotate(double angle);
-int lyte_rotate_at(double angle, int x, int y);
+int lyte_rotate_at(double angle, double x, double y);
 int lyte_scale(double scale_x, double scale_y);
-int lyte_scale_at(int scale_x, int scale_y, double x, double y);
+int lyte_scale_at(double scale_x, double scale_y, double x, double y);
 
 
 // -------------------------
@@ -221,8 +221,8 @@ int lyte_Image_cleanup(lyte_Image image);
 
 int lyte_get_image_width(lyte_Image image, int *val);
 int lyte_get_image_height(lyte_Image image, int *val);
-int lyte_draw_image(lyte_Image image, int x, int y);
-int lyte_draw_image_rect(lyte_Image image, int x, int y, int src_x, int src_y, int w, int h);
+int lyte_draw_image(lyte_Image image, double x, double y);
+int lyte_draw_image_rect(lyte_Image image, double x, double y, double src_x, double src_y, double w, double h);
 int lyte_set_canvas(lyte_Image image);
 int lyte_reset_canvas(void);
 int lyte_is_image_canvas(lyte_Image image, bool *val);
@@ -230,7 +230,7 @@ int lyte_is_image_canvas(lyte_Image image, bool *val);
 int lyte_new_imagebatch(lyte_Image image, lyte_ImageBatch *val);
 int lyte_ImageBatch_cleanup(lyte_ImageBatch imagebatch);
 int lyte_reset_imagebatch(lyte_ImageBatch imagebatch);
-int lyte_add_imagebatch_rect(lyte_ImageBatch imagebatch, int dest_x, int dest_y, int dest_width, int dest_height, int src_x, int src_y, int src_width, int src_height);
+int lyte_add_imagebatch_rect(lyte_ImageBatch imagebatch, double dest_x, double dest_y, double dest_width, double dest_height, double src_x, double src_y, double src_width, double src_height);
 int lyte_get_imagebatch_rect_count(lyte_ImageBatch imagebatch, int *val);
 int lyte_draw_imagebatch(lyte_ImageBatch imagebatch);
 
@@ -238,14 +238,14 @@ int lyte_draw_imagebatch(lyte_ImageBatch imagebatch);
 // core_shapes
 // -------------------------
 
-int lyte_draw_point(int x, int y);
-int lyte_draw_line(int x1, int y1, int x2, int y2);
-int lyte_draw_triangle(int ax, int ay, int bx, int by, int cx, int cy);
-int lyte_draw_triangle_line(int ax, int ay, int bx, int by, int cx, int cy);
-int lyte_draw_rect(int dest_x, int dest_y, int rect_width, int rect_height);
-int lyte_draw_rect_line(int dest_x, int dest_y, int rect_width, int rect_height);
-int lyte_draw_circle(int dest_x, int dest_y, int radius);
-int lyte_draw_circle_line(int dest_x, int dest_y, int radius);
+int lyte_draw_point(double x, double y);
+int lyte_draw_line(double x1, double y1, double x2, double y2);
+int lyte_draw_triangle(double ax, double ay, double bx, double by, double cx, double cy);
+int lyte_draw_triangle_line(double ax, double ay, double bx, double by, double cx, double cy);
+int lyte_draw_rect(double dest_x, double dest_y, double rect_width, double rect_height);
+int lyte_draw_rect_line(double dest_x, double dest_y, double rect_width, double rect_height);
+int lyte_draw_circle(double dest_x, double dest_y, double radius);
+int lyte_draw_circle_line(double dest_x, double dest_y, double radius);
 
 
 // -------------------------
@@ -307,7 +307,7 @@ int lyte_load_font(const char * font_path, double size, lyte_Font *val);
 int lyte_Font_cleanup(lyte_Font font);
 
 int lyte_set_font(lyte_Font font);
-int lyte_draw_text(const char * text, int dest_x, int dest_y);
+int lyte_draw_text(const char * text, double dest_x, double dest_y);
 int lyte_get_text_width(const char * text, int *val);
 int lyte_get_text_height(const char * text, int *val);
 

--- a/lyte_core/src/core_font.c
+++ b/lyte_core/src/core_font.c
@@ -243,7 +243,7 @@ int lyte_set_font(lyte_Font font) {
     return 0;
 }
 
-int lyte_draw_text(const char * text, int dest_x, int dest_y) {
+int lyte_draw_text(const char * text, double dest_x, double dest_y) {
     if (current_font == NULL) {
         fprintf(stderr, "No font set.\n");
         return -1;

--- a/lyte_core/src/core_image.c
+++ b/lyte_core/src/core_image.c
@@ -189,7 +189,7 @@ int lyte_is_image_canvas(lyte_Image image, bool *val) {
     return 0;
 }
 
-int lyte_draw_image(lyte_Image image, int x, int y) {
+int lyte_draw_image(lyte_Image image, double x, double y) {
     ImageItem *imageitem = image.ptr;
     if (!imageitem) {
         fprintf(stderr, "Image not found\n");
@@ -208,7 +208,7 @@ int lyte_draw_image(lyte_Image image, int x, int y) {
     return 0;
 }
 
-int lyte_draw_image_rect(lyte_Image image, int x, int y, int src_x, int src_y, int w, int h) {
+int lyte_draw_image_rect(lyte_Image image, double x, double y, double src_x, double src_y, double w, double h) {
     ImageItem *imageitem = image.ptr;
     if (!imageitem) {
         fprintf(stderr, "Image not found\n");
@@ -315,7 +315,7 @@ int lyte_reset_imagebatch(lyte_ImageBatch imagebatch) {
     }
     return 0;
 }
-int lyte_add_imagebatch_rect(lyte_ImageBatch imagebatch, int dest_x, int dest_y, int dest_width, int dest_height, int src_x, int src_y, int src_width, int src_height) {
+int lyte_add_imagebatch_rect(lyte_ImageBatch imagebatch, double dest_x, double dest_y, double dest_width, double dest_height, double src_x, double src_y, double src_width, double src_height) {
     ImageBatchItem *ibi = imagebatch.ptr;
     if (!ibi->rects) {
         // initial allocation

--- a/lyte_core/src/core_shapes.c
+++ b/lyte_core/src/core_shapes.c
@@ -15,22 +15,22 @@
 #define MAX_CIRCLE_TRIS 1024
 #endif
 
-int lyte_draw_point(int x, int y) {
+int lyte_draw_point(double x, double y) {
     sgp_draw_filled_rect(x, y, 1, 1);
     return 0;
 }
 
-int lyte_draw_line(int x1, int y1, int x2, int y2) {
+int lyte_draw_line(double x1, double y1, double x2, double y2) {
     sgp_draw_line(x1, y1, x2, y2);
     return 0;
 }
 
-int lyte_draw_triangle(int ax, int ay, int bx, int by, int cx, int cy) {
+int lyte_draw_triangle(double ax, double ay, double bx, double by, double cx, double cy) {
     sgp_draw_filled_triangle(ax, ay, bx, by, cx, cy);
     return 0;
 }
 
-int lyte_draw_triangle_line(int ax, int ay, int bx, int by, int cx, int cy) {
+int lyte_draw_triangle_line(double ax, double ay, double bx, double by, double cx, double cy) {
     sgp_line lines[4] = {
         (sgp_line){{ax, ay}, {bx, by}},
         (sgp_line){{bx, by}, {cx, cy}},
@@ -40,12 +40,12 @@ int lyte_draw_triangle_line(int ax, int ay, int bx, int by, int cx, int cy) {
     return 0;
 }
 
-int lyte_draw_rect(int x, int y, int w, int h) {
+int lyte_draw_rect(double x, double y, double w, double h) {
     sgp_draw_filled_rect(x, y, w, h);
     return 0;
 }
 
-int lyte_draw_rect_line(int x, int y, int w, int h) {
+int lyte_draw_rect_line(double x, double y, double w, double h) {
     sgp_line lines[4] = {
         (sgp_line){{x, y}, {x, y+h}},
         (sgp_line){{x, y+h}, {x+w, y+h}},
@@ -56,7 +56,7 @@ int lyte_draw_rect_line(int x, int y, int w, int h) {
     return 0;
 }
 
-int lyte_draw_circle(int dest_x, int dest_y, int radius) {
+int lyte_draw_circle(double dest_x, double dest_y, double radius) {
     float x = (float)dest_x;
     float y = (float)dest_y;
     float r = (float)radius;
@@ -79,7 +79,7 @@ int lyte_draw_circle(int dest_x, int dest_y, int radius) {
     return 0;
 }
 
-int lyte_draw_circle_line(int dest_x, int dest_y, int radius) {
+int lyte_draw_circle_line(double dest_x, double dest_y, double radius) {
     float x = (float)dest_x;
     float y = (float)dest_y;
     float r = (float)radius;

--- a/lyte_core/src/core_state.c
+++ b/lyte_core/src/core_state.c
@@ -183,7 +183,7 @@ int lyte_reset_matrix(void) {
     return 0;
 }
 
-int lyte_translate(int delta_x, int delta_y) {
+int lyte_translate(double delta_x, double delta_y) {
     sgp_translate(delta_x, delta_y);
     return 0;
 }
@@ -193,7 +193,7 @@ int lyte_rotate(double angle) {
     return 0;
 }
 
-int lyte_rotate_at(double angle, int x, int y) {
+int lyte_rotate_at(double angle, double x, double y) {
     sgp_rotate_at(angle, x, y);
     return 0;
 }
@@ -203,7 +203,7 @@ int lyte_scale(double scale_x, double scale_y) {
     return 0;
 }
 
-int lyte_scale_at(int scale_x, int scale_y, double x, double y) {
+int lyte_scale_at(double scale_x, double scale_y, double x, double y) {
     sgp_scale_at(scale_x, scale_y, x, y);
     return 0;
 }


### PR DESCRIPTION
This change is useful when you're using lyte.scale. With integers you lose precision because the coordinates you draw at get rounded before the scaling occurs.

For example, if I use lyte.scale(4, 4) and draw a sprite at x = 8.5
With this patch: The sprite is drawn floor(8.5 * 4) = 34
Before this patch: The sprite is drawn at floor(8.5) * 4 = 32

