### PR TITLE
Fix uniform float count being locked to 4

### DIFF
--- a/lyte_core/src/core_shader.c
+++ b/lyte_core/src/core_shader.c
@@ -423,7 +423,7 @@ int lyte_set_shader_uniform(lyte_Shader shader, const char * uniform_name, lyte_
             } else  if (uniform_value.options.vec_val.count > sud->float_count) {
                 fprintf(stderr, "warning: not enough uniform values sent\n");
             }
-            int count = MAX(MIN(uniform_value.options.vec_val.count, sud->float_count),4);
+            int count = MIN(MAX(uniform_value.options.vec_val.count, sud->float_count),4);
             for (int i=0; i<count; i++) {
                 shd->uniform_floats[sud->location+i] = uniform_value.options.vec_val.data[i];
             }


### PR DESCRIPTION
Fixed a small issue, the MIN and MAX functions were inverted when setting shader uniforms, causing every vecX to be treated like a vec4. For example, if you have `vec2 a` and `vec2 b`, setting `a` would spill over and also modify `b`.