### PR TITLE
Remove dependency on libgcc_seh when compiling for Windows from MinGW

### DIFF
--- a/lyte/CMakeLists.txt
+++ b/lyte/CMakeLists.txt
@@ -73,6 +73,11 @@ if( WIN_GUI )
     endif()
 endif()
 
+if(TOOLCHAIN_PREFIX STREQUAL x86_64-w64-mingw32)
+    message("==> Building statically with MinGW")
+    target_link_options(${PROJECT_NAME} PRIVATE "-static")
+endif()
+
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../lyte_core ${CMAKE_CURRENT_BINARY_DIR}/lyte_core)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../deps/lua-5.1.5 ${CMAKE_CURRENT_BINARY_DIR}/lua51)


### PR DESCRIPTION
(Noticed this when I first wanted to distribute Windows builds of my game)

Removes run-time dependency on libgcc_seh library (not available on many Windows computers).
- Uses `-static` flag on MinGW. 
- Checks the `TOOLCHAIN_PREFIX` instead of using the `MINGW` variable because in my testing the `MINGW` variable wasn't set when compiling from Docker for Windows.

This was only a thing when compiling with MinGW, MSVC never needed anything from `libgcc`. So this change is mainly intended to help anyone using the Docker scripts to compile, or using official releases.

Before:
```
> dumpbin /dependents .\lyte.exe

[...]

  Image has the following dependencies:

    ADVAPI32.dll
    GDI32.dll
    KERNEL32.dll
    msvcrt.dll
    SHELL32.dll
    USER32.dll
    libgcc_s_seh-1.dll <-------
```

After:
```
> dumpbin /dependents .\lyte.exe

[...]

  Image has the following dependencies:

    ADVAPI32.dll
    GDI32.dll
    KERNEL32.dll
    msvcrt.dll
    SHELL32.dll
    USER32.dll
```