### PR TITLE
Adjust mouse coordinates to compensate for high DPI scaling

### DIFF
--- a/lyte_core/src/core_input.c
+++ b/lyte_core/src/core_input.c
@@ -260,10 +260,31 @@ int lyte_get_mouse_x(int *val) {
     double x, y;
     glfwGetCursorPos(lytecore_state.window, &x, &y);
     inputstate.mouse_x = x;
-    *val = inputstate.mouse_x
-         - (lytecore_state.window_margins.left) // * lytecore_state.hidpi_xscale
-        //  - (lytecore_state.window_paddings.left)
-        ;
+
+    // the margins eat into our logical window
+    int effective_width = (lytecore_state.window_size.width
+        - lytecore_state.window_margins.left
+        - lytecore_state.window_margins.right
+    );
+
+#ifndef __APPLE__
+    // scale our coordinate by the DPI scale...
+    int scaled_x = inputstate.mouse_x / lytecore_state.hidpi_xscale;
+#else
+    // (on Apple platforms this coordinate is already scaled)
+    int scaled_x = inputstate.mouse_x;
+#endif
+
+    // ...then shift it by the margin origin...
+    scaled_x -= lytecore_state.window_margins.left;
+
+    // ...then re-scale it into the logical window size
+    scaled_x *= lytecore_state.window_size.width / (float)effective_width;
+
+    // ...then shift if by the padding origin...
+    // scaled_x -= lytecore_state.window_paddings.left;
+
+    *val = scaled_x;
     return 0;
 }
 
@@ -271,10 +292,31 @@ int lyte_get_mouse_y(int *val) {
     double x, y;
     glfwGetCursorPos(lytecore_state.window, &x, &y);
     inputstate.mouse_y = y;
-    *val = inputstate.mouse_y
-        - (lytecore_state.window_margins.top) // * lytecore_state.hidpi_xscale
-        // - lytecore_state.window_paddings.top
-        ;
+
+    // the margins eat into our logical window
+    int effective_height = (lytecore_state.window_size.height
+        - lytecore_state.window_margins.top
+        - lytecore_state.window_margins.bottom
+    );
+
+#ifndef __APPLE__
+    // scale our coordinate by the DPI scale...
+    int scaled_y = inputstate.mouse_y / lytecore_state.hidpi_yscale;
+#else
+    // (on Apple platforms this coordinate is already scaled)
+    int scaled_y = inputstate.mouse_y;
+#endif
+
+    // ...then re-scale it into the logical window size
+    scaled_y *= lytecore_state.window_size.height / (float)effective_height;
+
+    // ...then shift it by the margin origin...
+    scaled_y -= lytecore_state.window_margins.top;
+
+    // ...then shift it by the padding origin...
+    //scaled_y -= lytecore_state.window_paddings.top;
+
+    *val = scaled_y;
     return 0;
 }
 


### PR DESCRIPTION
It seems the mouse coordinates need to be adjusted when DPI scaling is in effect. This is logically pretty straightforward but I can't seem to get it quite right when there's both margin and padding. Padding isn't behaving quite the way I expect it but this could very easily be due to my poor spatial reasoning (I'm a little sad how long it took me to get the order of operations right as it is).

Anywhoo, it sounds like this should not be done on OSX or WASM targets...I couldn't find any other examples of platform specific #ifs or whatever so if you could point me to one I'd be happy to fix it (my dealing-with-C skills are also very rusty).