### PR TITLE
Update Dockerfile to fix ENV syntax

### DIFF
--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -2,7 +2,7 @@
 FROM ubuntu:18.04
 LABEL Description="Lyte2D Build Environment"
 
-ENV HOME /root
+ENV HOME=/root
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
ENV command should use the syntax:

ENV foo=bar

ref: https://www.docker.com/blog/docker-best-practices-using-arg-and-env-in-your-dockerfiles/